### PR TITLE
WIP: aggregate them metrics

### DIFF
--- a/lib/new_relic/harvest/supervisor.ex
+++ b/lib/new_relic/harvest/supervisor.ex
@@ -14,7 +14,8 @@ defmodule NewRelic.Harvest.Supervisor do
     Harvest.Collector.CustomEvent.HarvestCycle,
     Harvest.Collector.ErrorTrace.HarvestCycle,
     Harvest.TelemetrySdk.Logs.HarvestCycle,
-    Harvest.TelemetrySdk.Spans.HarvestCycle
+    Harvest.TelemetrySdk.Spans.HarvestCycle,
+    Harvest.TelemetrySdk.DimensionalMetrics.HarvestCycle
   ]
 
   def start_link(_) do

--- a/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
+++ b/test/telemetry_sdk/dimensional_metrics_harvester_test.exs
@@ -11,7 +11,7 @@ defmodule TelemetrySdk.DimensionalMetricsHarvesterTest do
         TelemetrySdk.DimensionalMetrics.Harvester
       )
 
-    metric1 = %{}
+    metric1 = %{type: :gauge, name: "cpu", value: 10, attributes: %{k8: true, id: 123}}
     GenServer.cast(harvester, {:report, metric1})
 
     metrics = GenServer.call(harvester, :gather_harvest)


### PR DESCRIPTION
With Cumulus mostly over, I had some extra time today and took at your old PR for dimensional metrics. I know has  interest in getting it over the finish line. 

Looking at the original comments by Vince, I think the missing piece was aggregating the dimensional metrics during the 5 second reporting interval.  I took a stab at it.  I didn't finish a draft of `summary` metric, that one requires a bit more manipulation. If you have some spare time, like to get your thoughts! 

Also, I think that common block is accurate for `count` and `summary` - https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api/#optional-map-attributes. 

But for `gauge`, it appears the `interval.ms` value isn't required.  It probably does no harm 😄  As an aside, the[ old NR Telemetry SDK specs](https://source.datanerd.us/agents/telemetry-sdk-specs/blob/master/capabilities.md#gauge) also show `gauge` without `interval.ms`


